### PR TITLE
fix cross-session settings race in card generation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import io
+import gc
 import time
 import os
 import random
@@ -28,7 +29,17 @@ DEFAULT_DESIGN_SETTINGS = {
     "card_draw_border": False,
     "card_border_color": (255, 255, 255),
     "neon_colors": [(255, 0, 100), (0, 200, 255), (0, 255, 120), (255, 255, 0)],
-    
+
+    "fonts_dict": {
+        "year": os.path.join("fonts", "Montserrat-Bold.ttf"),
+        "artist": os.path.join("fonts", "Montserrat-SemiBold.ttf"),
+        "song": os.path.join("fonts", "Montserrat-MediumItalic.ttf"),
+    },
+    "color_gradient": [
+        "#7030A0", "#E31C79", "#FF6B9D", "#FFA500",
+        "#FFD700", "#87CEEB", "#4169E1",
+    ],
+
     "google_font": "Montserrat",
 
     # QR Side Settings
@@ -405,33 +416,37 @@ def create_qr_with_neon_rings(qr_code, output_path):
     return output_path
 
 
-def get_year_color(year, all_years):
+def get_year_color(year, all_years, settings=None):
     """
     Get color for a year based on its percentile in the distribution.
     """
+    if settings is None:
+        settings = get_settings()
+    gradient = settings.get('color_gradient', [])
+
     sorted_years = sorted(all_years)
-    
+
     # Calculate percentile position
     count_below = sum(1 for y in sorted_years if y < year)
     count_equal = sum(1 for y in sorted_years if y == year)
     percentile = (count_below + count_equal / 2) / len(sorted_years)
-    
-    n_colors = len(db.get('color_gradient', []))
+
+    n_colors = len(gradient)
     if n_colors == 0:
         return (0.0, 0.0, 0.0) # Fallback to black if no colors
     if n_colors == 1:
-        return mcolors.to_rgba(db['color_gradient'][0])[:3]
-        
+        return mcolors.to_rgba(gradient[0])[:3]
+
     idx = percentile * (n_colors - 1)
     idx_low = int(np.floor(idx))
     idx_high = int(np.ceil(idx))
-    
+
     if idx_low == idx_high:
-        return mcolors.to_rgba(db['color_gradient'][idx_low])[:3]
-    
+        return mcolors.to_rgba(gradient[idx_low])[:3]
+
     # Linear interpolation
-    color_low = mcolors.to_rgba(db['color_gradient'][idx_low])
-    color_high = mcolors.to_rgba(db['color_gradient'][idx_high])
+    color_low = mcolors.to_rgba(gradient[idx_low])
+    color_high = mcolors.to_rgba(gradient[idx_high])
     frac = idx - idx_low
     
     r = color_low[0] + (color_high[0] - color_low[0]) * frac
@@ -497,7 +512,7 @@ def get_google_font(family_name, size, fallback_font):
 def get_font_for_setting(settings, size):
     """Get the preferred font (Google Font or fallback) for a given size."""
     try:
-        fallback = ImageFont.truetype(db['fonts_dict']['artist'], size)
+        fallback = ImageFont.truetype(settings['fonts_dict']['artist'], size)
     except:
         fallback = ImageFont.load_default()
         
@@ -843,11 +858,12 @@ def create_qr_with_neon_rings_in_memory(qr_code, seed=42, settings_override=None
         
     return img
 
-def create_solution_side_in_memory(song_name, artist, year, all_years):
+def create_solution_side_in_memory(song_name, artist, year, all_years, settings_override=None):
     """
     Create solution card and return the PIL Image object directly.
+    settings_override: dict of settings to override defaults.
     """
-    settings = get_settings()
+    settings = get_settings(settings_override)
     size = settings['card_size']
     margin = 150
     max_width = size - (2 * margin)
@@ -863,7 +879,7 @@ def create_solution_side_in_memory(song_name, artist, year, all_years):
     effective_year = year if year is not None else int(np.median(valid_years))
 
     # Get color for this year
-    color_rgb = get_year_color(effective_year, valid_years)
+    color_rgb = get_year_color(effective_year, valid_years, settings)
     color_int = tuple(int(c * 255) for c in color_rgb)
     
     # Create the base image
@@ -1007,11 +1023,11 @@ def fetch_no_api_data_from_list(urls, progress_bar=None):
 
     return songs
 
-def create_pdf_in_memory(songs, progress_bar=None):
+def create_pdf_in_memory(songs, progress_bar=None, settings_override=None):
     if not songs:
         return None
-    
-    settings = get_settings()
+
+    settings = get_settings(settings_override)
 
     buffer = io.BytesIO()
     c = canvas.Canvas(buffer, pagesize=A4)
@@ -1026,7 +1042,7 @@ def create_pdf_in_memory(songs, progress_bar=None):
     total_cards = len(songs)
     years = [song['year'] for song in songs]
 
-    card_label = db.get('card_label', None)
+    card_label = settings.get('card_label', None)
 
     for i in range(0, total_cards, 20):
         batch_songs = list(songs[i:i+20])
@@ -1047,16 +1063,19 @@ def create_pdf_in_memory(songs, progress_bar=None):
             x = margin_x + col * card_size
             y = height - margin_y - (row + 1) * card_size
             
-            base_qr = create_qr_code(song['link']) 
+            base_qr = create_qr_code(song['link'])
             # Per-card unique ring pattern based on link hash
-            qr_pil = create_qr_with_neon_rings_in_memory(base_qr, seed=hash(song['link'])) 
-            
+            qr_pil = create_qr_with_neon_rings_in_memory(base_qr, seed=hash(song['link']), settings_override=settings)
+
             img_byte_arr = io.BytesIO()
             qr_pil.save(img_byte_arr, format='PNG')
             img_byte_arr.seek(0)
-            
+
             c.drawImage(ImageReader(img_byte_arr), x, y, width=card_size, height=card_size)
-        
+
+            # Free the per-card rasters; otherwise peak memory grows with playlist size.
+            del base_qr, qr_pil, img_byte_arr
+
         c.showPage()
 
         # --- PAGE 2: BACK (SOLUTIONS - MIRRORED) ---
@@ -1072,19 +1091,25 @@ def create_pdf_in_memory(songs, progress_bar=None):
             y = height - margin_y - (row + 1) * card_size
             
             sol_pil = create_solution_side_in_memory(
-                song['name'], song['artist'], song['year'], years
-            ) 
+                song['name'], song['artist'], song['year'], years, settings_override=settings
+            )
+
             sol_byte_arr = io.BytesIO()
             sol_pil.save(sol_byte_arr, format='PNG')
             sol_byte_arr.seek(0)
-            
+
             c.drawImage(ImageReader(sol_byte_arr), x, y, width=card_size, height=card_size)
+
+            del sol_pil, sol_byte_arr
 
         if progress_bar:
             processed = min(i + 20, total_cards)
             percent = processed / total_cards
             progress_bar.progress(percent, text=f"Generated {processed}/{total_cards} cards...")
         c.showPage()
+
+        # Reclaim the batch's rasters before building the next page.
+        gc.collect()
 
     c.save()
     pdf_data = buffer.getvalue()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,25 +1,16 @@
 import streamlit as st
-import os
 from PIL import Image
 import pandas as pd
 import matplotlib.colors as mcolors
 import src.utils as utils
 
-if getattr(utils, 'db', None) is None or not utils.db:
-    utils.db = {
-        "fonts_dict": {
-            'year': os.path.join("fonts", "Montserrat-Bold.ttf"),
-            'artist': os.path.join("fonts", "Montserrat-SemiBold.ttf"),
-            'song': os.path.join("fonts", "Montserrat-MediumItalic.ttf")
-        },
-        "color_gradient": [
-            "#7030A0", "#E31C79", "#FF6B9D", "#FFA500", 
-            "#FFD700", "#87CEEB", "#4169E1"
-        ],
-        "card_size": 2000,
-        "neon_colors": [(255, 0, 100), (0, 200, 255), (0, 255, 120), (255, 255, 0)]
-    }
-db = utils.db
+# Per-session default for the year-color gradient. Settings are kept in
+# st.session_state (per user) rather than a shared module global to avoid
+# cross-session bleed when multiple users hit the same Streamlit server.
+DEFAULT_COLOR_GRADIENT = [
+    "#7030A0", "#E31C79", "#FF6B9D", "#FFA500",
+    "#FFD700", "#87CEEB", "#4169E1",
+]
 
 OUTPUT_DIR = "output"
 LINKS_FILE = "links.txt"
@@ -222,7 +213,7 @@ with st.sidebar:
 
     with tabs[2]:
         st.subheader("🎨 Color Gradient")
-        default_grad = db.get('color_gradient', ["#7030A0", "#E31C79", "#FF6B9D", "#FFA500", "#FFD700", "#87CEEB", "#4169E1"])
+        default_grad = DEFAULT_COLOR_GRADIENT
         st.session_state.color_gradient = dynamic_color_list(
             "gradient", 
             "Year Color Gradient", 
@@ -258,21 +249,22 @@ with st.sidebar:
             st.session_state.sol_title_color = st.color_picker("Title Color", value="#000000", key="sol_t_c")
             st.session_state.sol_title_bg = st.toggle("Draw Background Box", key="sol_t_bg")
 
-    # Update db with all settings
-    db.update({
+    # Build this session's settings. Kept in st.session_state (per user) and
+    # passed explicitly into utils functions, never written to a shared global.
+    st.session_state.design_settings = {
         "ink_saving_mode": ink_mode,
         "card_draw_border": border_mode,
         "card_background_color": "#FFFFFF" if ink_mode else qr_bg_color,
         "google_font": google_font,
-        "color_gradient": st.session_state.get('color_gradient', db.get('color_gradient')),
-        
+        "color_gradient": st.session_state.get('color_gradient', DEFAULT_COLOR_GRADIENT),
+
         "qr_bg_type": qr_bg_type,
         "qr_bg_color": qr_bg_color,
         "qr_bg_image": st.session_state.get('qr_bg_img'),
         "qr_bg_scale": st.session_state.get('qr_scale', 1.0),
         "qr_bg_offset_x": st.session_state.get('qr_x', 0.0),
         "qr_bg_offset_y": st.session_state.get('qr_y', 0.0),
-        "neon_colors": st.session_state.get('neon_colors', db.get('neon_colors')),
+        "neon_colors": st.session_state.get('neon_colors', utils.DEFAULT_DESIGN_SETTINGS['neon_colors']),
         "neon_ring_thickness": st.session_state.get('neon_thick', 12),
         "neon_ring_count": st.session_state.get('neon_count', 8),
         "qr_background_mode": qr_bg_mode,
@@ -300,7 +292,7 @@ with st.sidebar:
         "sol_title_size": st.session_state.get('sol_t_s', 80),
         "sol_title_color": st.session_state.get('sol_title_color', "#000000"),
         "sol_title_bg": st.session_state.get('sol_t_bg', False),
-    })
+    }
 with st.expander("Disclaimer, Accuracy & Support"):
     st.info("""
     **Why are some years wrong?**
@@ -469,18 +461,20 @@ if songs:
     if not valid_preview_years:
         valid_preview_years = [2000]
 
+    settings = st.session_state.get('design_settings')
+
     pcol1, pcol2 = st.columns(2)
     with pcol1:
         st.caption("QR Side")
         link_str = str(preview_song['Link']) if pd.notna(preview_song['Link']) else "https://open.spotify.com/"
         qr_img = utils.create_qr_code(link_str)
-        qr_card = utils.create_qr_with_neon_rings_in_memory(qr_img, seed=hash(link_str))
+        qr_card = utils.create_qr_with_neon_rings_in_memory(qr_img, seed=hash(link_str), settings_override=settings)
         st.image(qr_card, use_container_width=True)
     with pcol2:
         st.caption("Solution Side")
         sol_card = utils.create_solution_side_in_memory(
-            str(preview_song['Song']), str(preview_song['Artist']), 
-            preview_year, valid_preview_years
+            str(preview_song['Song']), str(preview_song['Artist']),
+            preview_year, valid_preview_years, settings_override=settings
         )
         st.image(sol_card, use_container_width=True)
 
@@ -511,7 +505,7 @@ if songs:
 
         with st.status("Generating cards...", expanded=True) as status:
             progress_bar = st.progress(0, text="Starting PDF generation...")
-            pdf_data = utils.create_pdf_in_memory(songs, progress_bar)
+            pdf_data = utils.create_pdf_in_memory(songs, progress_bar, settings_override=st.session_state.get('design_settings'))
             status.update(label="✅ All Cards Generated!", state="complete")
             progress_bar.empty()
 


### PR DESCRIPTION
Per-user design settings were stored in the module-level utils.db, which
is shared across all Streamlit sessions in one process. Concurrent users
overwrote each other's settings, so a generated PDF could use another
user's colors/fonts/title. Thread a per-session settings dict (held in
st.session_state) explicitly through the render functions instead.