### PR TITLE
Make src a regular package to fix concurrent-import crash

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+# Marks `src` as a regular package (not a namespace package).
+# Regular packages get per-module import locks, which prevents the
+# `KeyError: 'src.utils'` race that occurs when multiple Streamlit session
+# threads import this submodule concurrently on a cold start.


### PR DESCRIPTION
Adds src/__init__.py so concurrent Streamlit session threads no longer hit KeyError: 'src.utils' on cold start (namespace-package import race). Suspected fix for the multi-user 'app not working' crashes.